### PR TITLE
XR Core: Tick is skipped when frame state is invalid.

### DIFF
--- a/tracking_toolkit/xr_core/core.py
+++ b/tracking_toolkit/xr_core/core.py
@@ -286,6 +286,10 @@ def tick_xr():
 
     frame_state = _poll_xr()
 
+    # Skip if state is invalid/not ready.
+    if not frame_state:
+        return None
+
     xr.begin_frame(context.session)
 
     # Headless 'frame'.


### PR DESCRIPTION
Fixes #48 